### PR TITLE
fixed timeout parameter

### DIFF
--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/CMakeLists.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/CMakeLists.txt
@@ -74,7 +74,7 @@ target_include_directories(backendUnitTests PUBLIC "../backend")
 target_include_directories(backendUnitTests PUBLIC "../unitTestUtilities")
 
 include(GoogleTest)
-gtest_discover_tests(backendUnitTests PROPERTIES TIMEOUT 600)
+gtest_discover_tests(backendUnitTests DISCOVERY_TIMEOUT 600)
 
 IF(WIN32)
     INCLUDE(customthirdparty)

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/unitTestUtilitiesTests/CMakeLists.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/unitTestUtilitiesTests/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(
 target_include_directories(unitTestUtilitiesTests PUBLIC "../unitTestUtilities")
 
 include(GoogleTest)
-gtest_discover_tests(unitTestUtilitiesTests TIMEOUT 600)
+gtest_discover_tests(unitTestUtilitiesTests DISCOVERY_TIMEOUT 600)


### PR DESCRIPTION
should remove the error that the build sometimes gives when google test times out