### PR TITLE
V22F-125 Volume settings for auditory indicators

### DIFF
--- a/speed-dreams/source-2.2.3/data/data/menu/soundconfigmenu.xml
+++ b/speed-dreams/source-2.2.3/data/data/menu/soundconfigmenu.xml
@@ -123,6 +123,17 @@
 		<attstr name="font" val="medium"/>
 	</section>
 
+    <section name="intervention-volume-edit">
+        <attstr name="type" val="edit box"/>
+        <attnum name="max len" val="16"/>
+        <attstr name="tip" val="Setup your maximum auditory intervention volume (%)"/>
+        <attnum name="x" val="295"/>
+        <attnum name="y" val="200"/>
+        <attnum name="width" val="165"/>
+        <attstr name="h align" val="center"/>
+        <attstr name="font" val="medium"/>
+    </section>
+
 	<section name="musicstaticlabel">
 		<attstr name="type" val="label"/>
 		<attnum name="x" val="20"/>
@@ -256,6 +267,17 @@
 		<attnum name="width" val="220"/>
 		<attstr name="font" val="small_t"/>
 	</section>
+
+    <section name="8">
+        <attstr name="type" val="label"/>
+        <attnum name="x" val="20"/>
+        <attnum name="y" val="200"/>
+        <attstr name="text" val="Intervention volume:"/>
+        <attstr name="tip" val="Setup your auditory intervention volume (%)"/>
+        <attstr name="h align" val="right"/>
+        <attnum name="width" val="220"/>
+        <attstr name="font" val="small_t"/>
+    </section>
 
 	</section>
 

--- a/speed-dreams/source-2.2.3/data/data/menu/soundconfigmenu.xml
+++ b/speed-dreams/source-2.2.3/data/data/menu/soundconfigmenu.xml
@@ -271,7 +271,7 @@
     <section name="8">
         <attstr name="type" val="label"/>
         <attnum name="x" val="20"/>
-        <attnum name="y" val="200"/>
+        <attnum name="y" val="203"/>
         <attstr name="text" val="Intervention volume:"/>
         <attstr name="tip" val="Setup your auditory intervention volume (%)"/>
         <attstr name="h align" val="right"/>

--- a/speed-dreams/source-2.2.3/src/interfaces/sound.h
+++ b/speed-dreams/source-2.2.3/src/interfaces/sound.h
@@ -33,6 +33,9 @@
 
 #define SND_SCT_MUSIC                 "Music Settings"
 
+// SIMULATED DRIVING ASSISTANCE
+#define SND_SCT_INTERVENTION          "Auditory Intervention Settings"
+
 //#define MM_ATT_SOUND_ENABLE             "enable"
 //#define MM_VAL_SOUND_ENABLED            "enabled"
 //#define MM_VAL_SOUND_DISABLED           "disabled"

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.cpp
@@ -210,7 +210,7 @@ void OpenalSoundInterface::setNCars(int n_cars)
 Sound* OpenalSoundInterface::addSample (const char* filename, int flags, bool loop, bool static_pool)
 {
 	Sound* sound = new OpenalSound(filename, this, flags, loop, static_pool);
-    sound->setVolume(1.0f); // Will be automatically scaled down by the global gain.
+    sound->setVolume(getInterventionVolume()); // Will be automatically scaled down by the global gain.
 	sound_list.push_back(sound);
 	return sound;
 }

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.cpp
@@ -210,7 +210,7 @@ void OpenalSoundInterface::setNCars(int n_cars)
 Sound* OpenalSoundInterface::addSample (const char* filename, int flags, bool loop, bool static_pool)
 {
 	Sound* sound = new OpenalSound(filename, this, flags, loop, static_pool);
-    sound->setVolume(getInterventionVolume()); // Will be automatically scaled down by the global gain.
+    sound->setVolume(1.0f); // Will be automatically scaled down by the global gain.
 	sound_list.push_back(sound);
 	return sound;
 }
@@ -219,7 +219,7 @@ Sound* OpenalSoundInterface::addSample (const char* filename, int flags, bool lo
 /// @brief Updates all sounds related to interventions. Makes sure the right ones are playing and the right ones are stopped.
 /// @param p_carSoundData Data related to the car, like position data.
 /// @param p_interventionSounds The registered sounds
-void UpdateInterventionSounds(CarSoundData** p_carSoundData, std::unordered_map<InterventionAction, Sound*>& p_interventionSounds) {
+void OpenalSoundInterface::UpdateInterventionSounds(CarSoundData** p_carSoundData, std::unordered_map<InterventionAction, Sound*>& p_interventionSounds) {
     if(!SMediator::GetInstance()->GetIndicatorSetting(INDICATOR_AUDITORY)) return;
 
     for (const auto &item : p_interventionSounds) {
@@ -229,8 +229,8 @@ void UpdateInterventionSounds(CarSoundData** p_carSoundData, std::unordered_map<
         p_carSoundData[0]->getCarSpeed(u);
         sound->setSource(p, u);
         sound->setReferenceDistance(1.0f);
-        sound->setVolume(1.0f);
         sound->setPitch(1.0f);
+        sound->setVolume(GetInterventionVolume());
 
         sound->update();
     }

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.h
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.h
@@ -73,6 +73,11 @@ class OpenalSoundInterface : public SoundInterface
 	virtual SharedSourcePool* getSourcePool(void);
 	
 	virtual void mute(bool bOn = true);
+
+private:
+    // SIMULATED DRIVING ASSISTANCE
+    void UpdateInterventionSounds(CarSoundData** p_carSoundData, 
+        std::unordered_map<InterventionAction, Sound*>& p_interventionSounds);
 };
 
 struct sharedSource {

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
@@ -87,6 +87,9 @@ SoundInterface::SoundInterface(float sampling_rate, int n_channels)
 	
 	global_gain = 1.0f;
 	silent = false;
+
+    // SIMULATED DRIVING ASSISTANCE
+    InterventionVolume = 1.0f;
 }
 
 void SoundInterface::sortSingleQueue (CarSoundData** car_sound_data, QueueSoundMap* smap, int n_cars)
@@ -216,6 +219,20 @@ void SoundInterface::setInterventionSound(InterventionAction p_soundEvent, const
     intervention_sounds[p_soundEvent] = sound;
 }
 
+/// @brief  Retrieves the volume of the intervention sounds
+/// @return The volume
+float SoundInterface::getInterventionVolume() const
+{
+    return silent ? 0 : InterventionVolume;
+}
+
+/// @brief        Sets and clamps the volume of the interventions
+/// @param volume The raw volume to set
+void SoundInterface::setInterventionVolume(float volume)
+{
+    InterventionVolume = clamp(volume, 0.0f, 100.0f);
+}
+
 float SoundInterface::getGlobalGain() const
 { 
 	return silent ? 0 : global_gain; 
@@ -238,4 +255,14 @@ void SoundInterface::mute(bool bOn)
 	silent = bOn;
 	
 	GfLogInfo("Sound %s\n", silent ? "paused" : "restored");
+}
+
+/// @brief      Clamps a number to the given range
+/// @param n    The number
+/// @param low  The lower bound
+/// @param high The upper bound
+/// @return     The clamped number
+float SoundInterface::clamp(float n, float low, float high)
+{
+    return std::max(low, std::min(n, high));
 }

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
@@ -230,7 +230,7 @@ float SoundInterface::GetInterventionVolume() const
 /// @param volume The raw volume to set
 void SoundInterface::SetInterventionVolume(float volume)
 {
-    InterventionVolume = clamp(volume, 0.0f, 1.0f);
+    InterventionVolume = Clamp(volume, 0.0f, 1.0f);
 }
 
 float SoundInterface::getGlobalGain() const
@@ -262,7 +262,7 @@ void SoundInterface::mute(bool bOn)
 /// @param low  The lower bound
 /// @param high The upper bound
 /// @return     The clamped number
-float SoundInterface::clamp(float n, float low, float high)
+float SoundInterface::Clamp(float n, float low, float high)
 {
     return std::max(low, std::min(n, high));
 }

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
@@ -219,6 +219,7 @@ void SoundInterface::setInterventionSound(InterventionAction p_soundEvent, const
     intervention_sounds[p_soundEvent] = sound;
 }
 
+// SIMULATED DRIVING ASSISTANCE
 /// @brief  Retrieves the volume of the intervention sounds
 /// @return The volume
 float SoundInterface::GetInterventionVolume() const
@@ -226,6 +227,7 @@ float SoundInterface::GetInterventionVolume() const
     return silent ? 0 : InterventionVolume;
 }
 
+// SIMULATED DRIVING ASSISTANCE
 /// @brief        Sets and clamps the volume of the interventions
 /// @param volume The raw volume to set
 void SoundInterface::SetInterventionVolume(float volume)
@@ -257,6 +259,7 @@ void SoundInterface::mute(bool bOn)
 	GfLogInfo("Sound %s\n", silent ? "paused" : "restored");
 }
 
+// SIMULATED DRIVING ASSISTANCE
 /// @brief      Clamps a number to the given range
 /// @param n    The number
 /// @param low  The lower bound

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.cpp
@@ -221,16 +221,16 @@ void SoundInterface::setInterventionSound(InterventionAction p_soundEvent, const
 
 /// @brief  Retrieves the volume of the intervention sounds
 /// @return The volume
-float SoundInterface::getInterventionVolume() const
+float SoundInterface::GetInterventionVolume() const
 {
     return silent ? 0 : InterventionVolume;
 }
 
 /// @brief        Sets and clamps the volume of the interventions
 /// @param volume The raw volume to set
-void SoundInterface::setInterventionVolume(float volume)
+void SoundInterface::SetInterventionVolume(float volume)
 {
-    InterventionVolume = clamp(volume, 0.0f, 100.0f);
+    InterventionVolume = clamp(volume, 0.0f, 1.0f);
 }
 
 float SoundInterface::getGlobalGain() const

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.h
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.h
@@ -155,8 +155,8 @@ class SoundInterface {
 	virtual void setGlobalGain(float g);
 
     // SIMULATED DRIVING ASSISTANCE: add getter and setter for intervention volume
-    float getInterventionVolume() const;
-    void setInterventionVolume(float v);
+    float GetInterventionVolume() const;
+    void SetInterventionVolume(float p_volume);
 
 	virtual void mute(bool bOn = true);
 

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.h
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.h
@@ -162,7 +162,7 @@ class SoundInterface {
 
 private:
     // SIMULATED DRIVING ASSISTANCE: add helper function
-    float clamp(float volume, float low, float high);
+    float Clamp(float volume, float low, float high);
 };
 
 

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.h
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/SoundInterface.h
@@ -98,6 +98,9 @@ class SoundInterface {
 	/// Current global gain [0, 1] and mute flag. 
 	float global_gain;
 	bool silent;
+
+    // SIMULATED DRIVING ASSISTANCE: intervention volume [0, 1]
+    float InterventionVolume;
 	
 	/** Find the max amplitude sound in car_sound_data and put it in smap  */
 	void sortSingleQueue (CarSoundData** car_sound_data, QueueSoundMap* smap, int n_cars);
@@ -149,10 +152,17 @@ class SoundInterface {
 						sndVec3 c_obs = NULL, sndVec3 a_obs = NULL) = 0;
 
 	virtual float getGlobalGain() const;
-
 	virtual void setGlobalGain(float g);
 
+    // SIMULATED DRIVING ASSISTANCE: add getter and setter for intervention volume
+    float getInterventionVolume() const;
+    void setInterventionVolume(float v);
+
 	virtual void mute(bool bOn = true);
+
+private:
+    // SIMULATED DRIVING ASSISTANCE: add helper function
+    float clamp(float volume, float low, float high);
 };
 
 

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/grsound.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/grsound.cpp
@@ -159,7 +159,7 @@ void grInitSound(tSituation* s, int ncars)
 	soundInitialized = 1;
 
     // SIMULATED DRIVING ASSISTANCE: Added intervention sound initialization
-    sound_interface->setInterventionVolume(interventionVolume);
+    sound_interface->SetInterventionVolume(interventionVolume / 100.0f);
     for (const auto &item : InterventionConfig::GetInstance()->GetSounds()) {
         sound_interface->setInterventionSound(item.first, item.second);
     }

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/grsound.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/grsound.cpp
@@ -51,6 +51,10 @@ void grInitSound(tSituation* s, int ncars)
 	void *paramHandle = GfParmReadFile(fnbuf, GFPARM_RMODE_REREAD | GFPARM_RMODE_CREAT);
 	const char *optionName = GfParmGetStr(paramHandle, SND_SCT_SOUND, SND_ATT_SOUND_STATE, soundOpenALStr);
 	float global_volume = GfParmGetNum(paramHandle, SND_SCT_SOUND, SND_ATT_SOUND_VOLUME, "%", 100.0f);
+
+    // SIMULATED DRIVING ASSISTANCE
+    float interventionVolume = GfParmGetNum(paramHandle, SND_SCT_INTERVENTION, SND_ATT_SOUND_VOLUME, "%", 100.0f);
+
 	if (!strcmp(optionName, soundDisabledStr)) {
 		sound_mode = DISABLED;
 	} else if (!strcmp(optionName, soundOpenALStr)) {
@@ -155,6 +159,7 @@ void grInitSound(tSituation* s, int ncars)
 	soundInitialized = 1;
 
     // SIMULATED DRIVING ASSISTANCE: Added intervention sound initialization
+    sound_interface->setInterventionVolume(interventionVolume);
     for (const auto &item : InterventionConfig::GetInstance()->GetSounds()) {
         sound_interface->setInterventionSound(item.first, item.second);
     }

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
@@ -221,7 +221,7 @@ static void changeMusicVolume(void * )
     GfuiEditboxSetString(scrHandle, MusicVolumeValueId, buf);
 }
 
-
+/// @brief Reads the value from the textbox, clamps it stores it as member and writes the value back.
 static void ChangeInterventionVolume(void*)
 {
     // Get volume from text box, clamped between 0% and 100%

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
@@ -221,6 +221,7 @@ static void changeMusicVolume(void * )
     GfuiEditboxSetString(scrHandle, MusicVolumeValueId, buf);
 }
 
+// SIMULATED DRIVING ASSISTANCE
 /// @brief Reads the value from the textbox, clamps it stores it as member and writes the value back.
 static void ChangeInterventionVolume(void*)
 {

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
@@ -295,9 +295,3 @@ void* SoundMenuInit(void *prevMenu)
 
 	return scrHandle;
 }
-
-// SIMULATED DRIVING ASSISTANCE: add helper function
-float clamp(float x, float lower, float upper)
-{
-    return std::min(upper, std::max(x, lower));
-}

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/confscreens/soundconfig.cpp
@@ -62,7 +62,7 @@ static int MusicVolumeValueId;
 
 // SIMULATED DRIVING ASSISTANCE
 // Auditory interventions volume
-static float InterventionVolumeValue = 100.0f;
+static float InterventionVolumeValue = 20.0f;
 static int InterventionVolumeControl;
 
 // gui screen handles.

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -72,7 +72,7 @@ Changed:
                 added setInterventionSound()
                 added SetInterventionVolume()
                 added GetInterventionVolume()
-                added InterventionVolume member to init
+                changed SoundInterface(): added InterventionVolume member init
                 added Clamp() helper function
             SoundInterface.h
                 added setInterventionSound()
@@ -105,6 +105,7 @@ Changed:
                 confscreens/soundconfig.cpp
                     added ChangeInterventionVolume()
                     added logic to create new controls for intervention volume and store their data
+                    changed readSoundCfg()
         graphic/
             ssggraph/
                 CMakeLists.txt added connection to frontend module

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -48,6 +48,8 @@ Changed:
     interfaces/
         playerpref.h
             added HM_ADRV_FILE define
+        sound.h
+            added intervention sound volume xml parameter 
     modules/
         racing/standardgame
             racesituation.cpp
@@ -58,16 +60,27 @@ Changed:
                 added backend
             grsound.cpp
                 added intervention sound initialization
+                added intervention sound volume setting
             OpenalSound.cpp
                 added check for playing state
+            OpenalSoundInterface.cpp
+                added UpdateInterventionSounds()
             OpenalSoundInterface.cpp
                 added UpdateInterventionSounds()
                 added update and starting of intervention sounds
             SoundInterface.cpp
                 added setInterventionSound()
+                added SetInterventionVolume()
+                added GetInterventionVolume()
+                added InterventionVolume member to init
+                added Clamp() helper function
             SoundInterface.h
                 added setInterventionSound()
                 added intervention_sounds map
+                added SetInterventionVolume()
+                added GetInterventionVolume()
+                added InterventionVolume member
+                added Clamp() helper function
         userinterface/
             legacymenu.h 
                   ActivateResearcherMenu()
@@ -89,6 +102,9 @@ Changed:
                         removed RmProgressiveTimeModifier implementation and calls
                     racestopmenu.cpp
                         removed rmProgressiveTimeModifier.start() call
+                confscreens/soundconfig.cpp
+                    added ChangeInterventionVolume()
+                    added logic to create new controls for intervention volume and store their data
         graphic/
             ssggraph/
                 CMakeLists.txt added connection to frontend module
@@ -98,13 +114,15 @@ Changed:
                     changed grInitBoardCar() 
                     changed refreshBoard()
                 grboard.h
-                    added grDispIntervention() 
-
+                    added grDispIntervention()  
 
 
   data/
-    data/CMakeLists.txt
-        added intervention folder
+    data/
+        CMakeLists.txt
+            added intervention folder
+        menu/soundconfigmenu.xml
+            added controls for intervention sound volume
         
   cmake/
     checks.cmake


### PR DESCRIPTION
Added functionality to the sound settings menu to set the volume of the intervention audio volume. These settings are also stored in the local user config.