### PR TITLE
V22F-408 Remove indicator icon/text dependency

### DIFF
--- a/speed-dreams/source-2.2.3/data/data/intervention/config.xml
+++ b/speed-dreams/source-2.2.3/data/data/intervention/config.xml
@@ -5,25 +5,25 @@
         <section name ="none">
             <section name="texture">
                 <attstr name ="source" val="Intervention_Steer_None_Proto_256.png"/>
-                <attnum name ="xpos"   val="0"/>
-                <attnum name ="ypos"   val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0.02"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="None"/>
-                <attnum name ="xpos"    val="0"/>
-                <attnum name ="ypos"    val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0"/>
             </section>
         </section>
         <section name ="steer left">
             <section name="texture">
                 <attstr name ="source" val="Intervention_Steer_Left_Proto_256.png"/>
-                <attnum name ="xpos"   val="0"/>
-                <attnum name ="ypos"   val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0.02"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="Steer left"/>
-                <attnum name ="xpos"    val="0"/>
-                <attnum name ="ypos"    val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0"/>
             </section>
             <section name="sound">
                 <attstr name ="source" val="left.wav"/>
@@ -32,13 +32,13 @@
         <section name ="steer right">
             <section name="texture">
                 <attstr name ="source" val="Intervention_Steer_Right_Proto_256.png"/>
-                <attnum name ="xpos"   val="0"/>
-                <attnum name ="ypos"   val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0.02"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="Steer right"/>
-                <attnum name ="xpos"    val="0"/>
-                <attnum name ="ypos"    val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0"/>
             </section>
             <section name="sound">
                 <attstr name ="source" val="right.wav"/>
@@ -47,13 +47,13 @@
         <section name ="brake">
             <section name="texture">
                 <attstr name ="source" val="Intervention_Brake_Proto_256.png"/>
-                <attnum name ="xpos"   val="0"/>
-                <attnum name ="ypos"   val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0.02"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="Brake"/>
-                <attnum name ="xpos"    val="0"/>
-                <attnum name ="ypos"    val="0"/>
+                <attnum name ="xpos"   val="0.75"/>
+                <attnum name ="ypos"   val="0"/>
             </section>
             <section name="sound">
                 <attstr name ="source" val="brake.wav"/>

--- a/speed-dreams/source-2.2.3/data/data/intervention/config.xml
+++ b/speed-dreams/source-2.2.3/data/data/intervention/config.xml
@@ -6,7 +6,7 @@
             <section name="texture">
                 <attstr name ="source" val="Intervention_Steer_None_Proto_256.png"/>
                 <attnum name ="xpos"   val="0.75"/>
-                <attnum name ="ypos"   val="0.02"/>
+                <attnum name ="ypos"   val="0.03"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="None"/>
@@ -18,7 +18,7 @@
             <section name="texture">
                 <attstr name ="source" val="Intervention_Steer_Left_Proto_256.png"/>
                 <attnum name ="xpos"   val="0.75"/>
-                <attnum name ="ypos"   val="0.02"/>
+                <attnum name ="ypos"   val="0.03"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="Steer left"/>
@@ -33,7 +33,7 @@
             <section name="texture">
                 <attstr name ="source" val="Intervention_Steer_Right_Proto_256.png"/>
                 <attnum name ="xpos"   val="0.75"/>
-                <attnum name ="ypos"   val="0.02"/>
+                <attnum name ="ypos"   val="0.03"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="Steer right"/>
@@ -48,7 +48,7 @@
             <section name="texture">
                 <attstr name ="source" val="Intervention_Brake_Proto_256.png"/>
                 <attnum name ="xpos"   val="0.75"/>
-                <attnum name ="ypos"   val="0.02"/>
+                <attnum name ="ypos"   val="0.03"/>
             </section>
             <section name="text">
                 <attstr name ="content" val="Brake"/>

--- a/speed-dreams/source-2.2.3/data/data/menu/ResearcherMenu.xml
+++ b/speed-dreams/source-2.2.3/data/data/menu/ResearcherMenu.xml
@@ -36,8 +36,8 @@
         <!-- Checkboxes for selecting how to indicate an intervention -->
         <section name="CheckboxIndicatorAuditory">
             <attstr name="type" val="check box"/>
-            <attstr name="text" val="Auditory"/>
-            <attstr name="tip" val="Enable/Disable Auditory indication of interventions"/>
+            <attstr name="text" val="Audio"/>
+            <attstr name="tip" val="Enable/Disable auditory indication of interventions"/>
             <attnum name="x" val="140"/>
             <attnum name="y" val="370"/>
             <attnum name="image width" val="20"/>
@@ -49,8 +49,8 @@
 
         <section name="CheckboxIndicatorVisual">
             <attstr name="type" val="check box"/>
-            <attstr name="text" val="Visual"/>
-            <attstr name="tip" val="Enable/Disable Visual indication of interventions"/>
+            <attstr name="text" val="Icon"/>
+            <attstr name="tip" val="Enable/Disable icon indication of interventions"/>
             <attnum name="x" val="140"/>
             <attnum name="y" val="340"/>
             <attnum name="image width" val="20"/>
@@ -62,8 +62,8 @@
 
         <section name="CheckboxIndicatorTextual">
             <attstr name="type" val="check box"/>
-            <attstr name="text" val="Textual"/>
-            <attstr name="tip" val="Enable/Disable Textual indication of interventions"/>
+            <attstr name="text" val="Text"/>
+            <attstr name="tip" val="Enable/Disable text indication of interventions"/>
             <attnum name="x" val="140"/>
             <attnum name="y" val="310"/>
             <attnum name="image width" val="20"/>

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -411,76 +411,31 @@ void cGrBoard::refreshBoard(tSituation *s, const cGrFrameInfo* frameInfo,
         grDispSplitScreenIndicator();
     }
 
-  // SIMULATED DRIVING ASSISTANCE
-  // Draw the intervention only when enabled in the settings
-  if (SMediator::GetInstance()->GetIndicatorSettings().Visual)
-  {
-      DispIntervention();
-  }
+    // SIMULATED DRIVING ASSISTANCE: displays the current intervention
+    DispIntervention();
  
     if (debugFlag)
         grDispDebug(s, frameInfo);
+
     if (counterFlag)
         grDispCounterBoard2();
 }
 
 // SIMULATED DRIVING ASSISTANCE
 /// @brief Displays the currently active intervention in InterventionConfig
+///        Depending on the indicator settings that are currently active.
 void cGrBoard::DispIntervention() 
 {
     tIndicator settings = SMediator::GetInstance()->GetIndicatorSettings();
-
-    if (settings.Visual)  
+    if (settings.Icon)  
         DispInterventionIcon();
 
-    if (settings.Textual) 
+    if (settings.Text) 
         DispInterventionText();
-
-    //tTextureData textureData = InterventionConfig::GetInstance()->GetCurrentInterventionTexture();
-    //if (!textureData.Texture) return;
-
-    //// Dimensions of the icon on the screen (will be put in XML settings file later)
-    //float iconWidth = 100;
-    //float iconHeight = 100;
-
-    //// Duplicate the current matrix and enable opengl settings.
-    //glPushMatrix();
-    //glEnable(GL_BLEND);
-    //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    //glEnable(GL_TEXTURE_2D);
-    //glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
-
-    //// Translate the opengl matrix to the position on the screen where we want to display the texture, and load the texture.
-    //glTranslatef(
-    //    1.5 * centerAnchor - 0.5 * iconWidth + textureData.Position.X,
-    //    BOTTOM_ANCHOR + 10 + textureData.Position.Y,
-    //    0);
-    //glBindTexture(GL_TEXTURE_2D, textureData.Texture->getTextureHandle());
-    //
-    //// Draw the texture as a Triangle Strip. 
-    //// glTexCoord2f defines point of the texture that you take (0-1).
-    //// glVertex2f then defines where to place this on the screen (relative to the current matrix)
-    //glBegin(GL_TRIANGLE_STRIP);
-    //glColor4f(1.0, 1.0, 1.0, 0.0);
-    //glTexCoord2f(0.0, 0.0); glVertex2f(0, 0);
-    //glTexCoord2f(0.0, 1.0); glVertex2f(0, iconHeight);
-    //glTexCoord2f(1.0, 0.0); glVertex2f(iconWidth, 0);
-    //glTexCoord2f(1.0, 1.0); glVertex2f(iconWidth, iconHeight);
-    //glEnd();
-
-    //// Unbind the texture and pop the translated matrix of the stack.
-    //glBindTexture(GL_TEXTURE_2D, 0);
-
-    //// Also draw the text only when enabled in the settings
-    //if (SMediator::GetInstance()->GetIndicatorSettings().Textual)
-    //{
-    //    tTextData textData = InterventionConfig::GetInstance()->GetCurrentInterventionText();
-    //    GfuiDrawString(textData.Text, normal_color_, GFUI_FONT_LARGE_C, textData.Position.X, textData.Position.Y);
-    //}
-
-    //glPopMatrix();
 }
 
+// SIMULATED DRIVING ASSISTANCE
+/// @brief Displays the intervention icon (if the texture was loaded correctly)
 void cGrBoard::DispInterventionIcon()
 {
     tTextureData textureData = InterventionConfig::GetInstance()->GetCurrentInterventionTexture();
@@ -520,6 +475,8 @@ void cGrBoard::DispInterventionIcon()
     glPopMatrix();
 }
 
+// SIMULATED DRIVING ASSISTANCE
+/// @brief Displays the intervention text
 void cGrBoard::DispInterventionText()
 {
     tTextData textData = InterventionConfig::GetInstance()->GetCurrentInterventionText();

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -428,6 +428,61 @@ void cGrBoard::refreshBoard(tSituation *s, const cGrFrameInfo* frameInfo,
 /// @brief Displays the currently active intervention in InterventionConfig
 void cGrBoard::DispIntervention() 
 {
+    tIndicator settings = SMediator::GetInstance()->GetIndicatorSettings();
+
+    if (settings.Visual)  
+        DispInterventionIcon();
+
+    if (settings.Textual) 
+        DispInterventionText();
+
+    //tTextureData textureData = InterventionConfig::GetInstance()->GetCurrentInterventionTexture();
+    //if (!textureData.Texture) return;
+
+    //// Dimensions of the icon on the screen (will be put in XML settings file later)
+    //float iconWidth = 100;
+    //float iconHeight = 100;
+
+    //// Duplicate the current matrix and enable opengl settings.
+    //glPushMatrix();
+    //glEnable(GL_BLEND);
+    //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    //glEnable(GL_TEXTURE_2D);
+    //glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+
+    //// Translate the opengl matrix to the position on the screen where we want to display the texture, and load the texture.
+    //glTranslatef(
+    //    1.5 * centerAnchor - 0.5 * iconWidth + textureData.Position.X,
+    //    BOTTOM_ANCHOR + 10 + textureData.Position.Y,
+    //    0);
+    //glBindTexture(GL_TEXTURE_2D, textureData.Texture->getTextureHandle());
+    //
+    //// Draw the texture as a Triangle Strip. 
+    //// glTexCoord2f defines point of the texture that you take (0-1).
+    //// glVertex2f then defines where to place this on the screen (relative to the current matrix)
+    //glBegin(GL_TRIANGLE_STRIP);
+    //glColor4f(1.0, 1.0, 1.0, 0.0);
+    //glTexCoord2f(0.0, 0.0); glVertex2f(0, 0);
+    //glTexCoord2f(0.0, 1.0); glVertex2f(0, iconHeight);
+    //glTexCoord2f(1.0, 0.0); glVertex2f(iconWidth, 0);
+    //glTexCoord2f(1.0, 1.0); glVertex2f(iconWidth, iconHeight);
+    //glEnd();
+
+    //// Unbind the texture and pop the translated matrix of the stack.
+    //glBindTexture(GL_TEXTURE_2D, 0);
+
+    //// Also draw the text only when enabled in the settings
+    //if (SMediator::GetInstance()->GetIndicatorSettings().Textual)
+    //{
+    //    tTextData textData = InterventionConfig::GetInstance()->GetCurrentInterventionText();
+    //    GfuiDrawString(textData.Text, normal_color_, GFUI_FONT_LARGE_C, textData.Position.X, textData.Position.Y);
+    //}
+
+    //glPopMatrix();
+}
+
+void cGrBoard::DispInterventionIcon()
+{
     tTextureData textureData = InterventionConfig::GetInstance()->GetCurrentInterventionTexture();
     if (!textureData.Texture) return;
 
@@ -444,11 +499,11 @@ void cGrBoard::DispIntervention()
 
     // Translate the opengl matrix to the position on the screen where we want to display the texture, and load the texture.
     glTranslatef(
-        1.5 * centerAnchor - 0.5 * iconWidth + textureData.Position.X,
-        BOTTOM_ANCHOR + 10 + textureData.Position.Y,
+        rightAnchor * textureData.Position.X,
+        TOP_ANCHOR  * textureData.Position.Y,
         0);
     glBindTexture(GL_TEXTURE_2D, textureData.Texture->getTextureHandle());
-    
+
     // Draw the texture as a Triangle Strip. 
     // glTexCoord2f defines point of the texture that you take (0-1).
     // glVertex2f then defines where to place this on the screen (relative to the current matrix)
@@ -462,15 +517,16 @@ void cGrBoard::DispIntervention()
 
     // Unbind the texture and pop the translated matrix of the stack.
     glBindTexture(GL_TEXTURE_2D, 0);
-
-    // Also draw the text only when enabled in the settings
-    if (SMediator::GetInstance()->GetIndicatorSettings().Textual)
-    {
-        tTextData textData = InterventionConfig::GetInstance()->GetCurrentInterventionText();
-        GfuiDrawString(textData.Text, normal_color_, GFUI_FONT_LARGE_C, textData.Position.X, textData.Position.Y);
-    }
-
     glPopMatrix();
+}
+
+void cGrBoard::DispInterventionText()
+{
+    tTextData textData = InterventionConfig::GetInstance()->GetCurrentInterventionText();
+    GfuiDrawString(
+        textData.Text, normal_color_, GFUI_FONT_LARGE_C, 
+        rightAnchor * textData.Position.X,
+        TOP_ANCHOR  * textData.Position.Y);
 }
 
 // SIMULATED DRIVING ASSISTANCE
@@ -488,7 +544,7 @@ void LoadInterventionData()
     void* xmlHandle = config->GetXmlHandle();
     for (int i = 0; i < interventionCnt; i++)
     {
-        int xPos, yPos;
+        float xPos, yPos;
 
         // Textures
         snprintf(path, sizeof(path), "%s/%s/%s", PRM_SECT_INTERVENTIONS, s_actionEnumString[i], PRM_SECT_TEXTURE);

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.h
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.h
@@ -50,6 +50,7 @@ class cGrBoard
 
     void grDispCounterBoard2();
 
+    // SIMULATED DRIVING ASSISTANCE: add display intervention methods
     void DispIntervention();
     void DispInterventionIcon();
     void DispInterventionText();

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.h
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.h
@@ -51,6 +51,8 @@ class cGrBoard
     void grDispCounterBoard2();
 
     void DispIntervention();
+    void DispInterventionIcon();
+    void DispInterventionText();
 
 private:
     //Dash colour handling

--- a/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/sound/snddefault/OpenalSoundInterface.cpp
@@ -220,7 +220,7 @@ Sound* OpenalSoundInterface::addSample (const char* filename, int flags, bool lo
 /// @param p_carSoundData Data related to the car, like position data.
 /// @param p_interventionSounds The registered sounds
 void OpenalSoundInterface::UpdateInterventionSounds(CarSoundData** p_carSoundData, std::unordered_map<InterventionAction, Sound*>& p_interventionSounds) {
-    if(!SMediator::GetInstance()->GetIndicatorSettings().Auditory) return;
+    if(!SMediator::GetInstance()->GetIndicatorSettings().Audio) return;
 
     for (const auto &item : p_interventionSounds) {
         Sound* sound = item.second;

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/ResearcherMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/ResearcherMenu.cpp
@@ -24,7 +24,7 @@ InterventionType m_interventionType;
 Track m_track;
 
 // Participant control
-tParticipantControl m_pControl = {false, true, true, true};
+tParticipantControl m_pControl = { false, true, true, true };
 
 // Force feedback manager
 extern TGFCLIENT_API ForceFeedbackManager forceFeedback;
@@ -72,23 +72,23 @@ static void SelectSpeedControl(tCheckBoxInfo* p_info)
 
 /// @brief        Enables/disables the auditory indication for interventions
 /// @param p_info Information on the checkbox
-static void SelectAuditory(tCheckBoxInfo* p_info)
+static void SelectAudio(tCheckBoxInfo* p_info)
 {
-    m_indicators.Auditory = p_info->bChecked;
+    m_indicators.Audio = p_info->bChecked;
 }
 
 /// @brief        Enables/disables the visual indication for interventions
 /// @param p_info Information on the checkbox
-static void SelectVisual(tCheckBoxInfo* p_info)
+static void SelectIcon(tCheckBoxInfo* p_info)
 {
-    m_indicators.Visual = p_info->bChecked;
+    m_indicators.Icon = p_info->bChecked;
 }
 
 /// @brief        Enables/disables the textual indication for interventions
 /// @param p_info Information on the checkbox
-static void SelectTextual(tCheckBoxInfo* p_info)
+static void SelectText(tCheckBoxInfo* p_info)
 {
-    m_indicators.Textual = p_info->bChecked;
+    m_indicators.Text = p_info->bChecked;
 }
 
 /// @brief        Sets the interventionType to no signals
@@ -239,9 +239,9 @@ void* ResearcherMenuInit(void* p_nextMenu)
     GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxTaskSpeedControl", NULL, SelectSpeedControl);
 
     // Indicator checkboxes controls
-    GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxIndicatorAuditory", NULL, SelectAuditory);
-    GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxIndicatorVisual", NULL, SelectVisual);
-    GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxIndicatorTextual", NULL, SelectTextual);
+    GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxIndicatorAuditory", NULL, SelectAudio);
+    GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxIndicatorVisual", NULL, SelectIcon);
+    GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxIndicatorTextual", NULL, SelectText);
 
     // InterventionType checkboxes controls
     GfuiMenuCreateCheckboxControl(s_scrHandle, param, "CheckboxTypeNoSignals", NULL, SelectTypeNoSignals);

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -119,6 +119,8 @@ Changed:
                     included "InterventionConfig.h"
 
                     added   DispIntervention()
+                    added   DispInterventionIcon();
+                    added   DispInterventionText();
                     added   LoadInterventionTextures()
 
                     changed cGrBoard(): removed assignments of removed members
@@ -151,7 +153,9 @@ Changed:
                     removed constants tracking the number of states of removed elements
 
                 grboard.h
-                    added   DispIntervention()  
+                    added   DispIntervention() 
+                    added   DispInterventionIcon();
+                    added   DispInterventionText();
 
                     removed grDispGGraph()
                     removed grDispEngineLeds()

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/ConfigEnums.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/ConfigEnums.h
@@ -10,9 +10,9 @@ typedef unsigned int Task;
 /// @brief The different ways a user can be indicated about an intervention
 typedef struct Indicator
 {
-    bool Auditory;
-    bool Visual;
-    bool Textual;
+    bool Audio;
+    bool Icon;
+    bool Text;
 } tIndicator;
 
 /// @brief The different interventions that can be done

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/ConfigTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/ConfigTests.cpp
@@ -39,20 +39,21 @@ TEST_CASE(ConfigTests, TaskTestsSpeedControl, TaskTest, (TASK_SPEED_CONTROL))
 /// @brief         Tests if the SDAConfig sets and gets the IndicatorSettings correctly
 /// @param p_bool1 First bool
 /// @param p_bool2 Second bool
-void IndicatorTest(bool p_bool1, bool p_bool2)
+void IndicatorTest(bool p_bool1, bool p_bool2, bool p_bool3)
 {
     SDAConfig config;
-    tIndicator arr = { p_bool1, p_bool2 };
+    tIndicator arr = { p_bool1, p_bool2, p_bool3 };
     config.SetIndicatorSettings(arr);
     tIndicator indicator = config.GetIndicatorSettings();
-    ASSERT_EQ(arr.Auditory, indicator.Auditory);
-    ASSERT_EQ(arr.Visual, indicator.Visual);
+    ASSERT_EQ(arr.Audio, indicator.Audio);
+    ASSERT_EQ(arr.Icon, indicator.Icon);
+    ASSERT_EQ(arr.Text, indicator.Text);
 }
 
 /// @brief Tests the SDAConfig IndicatorSetting for every possible boolean combination
 BEGIN_TEST_COMBINATORIAL(ConfigTests, IndicatorSettings)
 bool booleans[] = {false,true};
-END_TEST_COMBINATORIAL2(IndicatorTest,booleans,2,booleans,2)
+END_TEST_COMBINATORIAL3(IndicatorTest, booleans, 2, booleans, 2, booleans, 2)
 
 /// @brief Tests if the SDAConfig sets and gets the MaxTime correctly
 TEST(ConfigTests, MaxTimeTest)
@@ -106,4 +107,4 @@ void TestBoolArr(bool p_bool1, bool p_bool2, bool p_bool3, bool p_bool4, bool p_
 /// @brief Tests the SDAConfig DataCollectionSetting for every possible boolean combination
 BEGIN_TEST_COMBINATORIAL(ConfigTests, DataCollectionSettings)
 bool booleans[] = {false,true};
-END_TEST_COMBINATORIAL5(TestBoolArr,booleans,2,booleans,2,booleans,2,booleans,2,booleans,2)
+END_TEST_COMBINATORIAL5(TestBoolArr, booleans, 2, booleans, 2, booleans, 2, booleans, 2, booleans, 2)

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/InterventionConfig.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/InterventionConfig.h
@@ -23,10 +23,10 @@ static const char* s_actionEnumString[NUM_INTERVENTION_ACTION] = {
     "none", "steer left", "steer right", "brake"
 };
 
-/// @brief Represents a position on screen
+/// @brief Represents a position on screen as percentages of the full screen.
 typedef struct ScreenPosition 
 {
-    int X, Y;
+    float X, Y;
 } tScreenPosition;
 
 /// @brief Stores all data of a texture


### PR DESCRIPTION
Removed the dependency between the icon indicator and text indicator. Now both can be enabled/disabled seperately. To do this I also updated the xml file, now the xpos and ypos are the position of the element based on the percentage of the screen.