### PR TITLE
Update gitignore to ignore any cmake build folders

### DIFF
--- a/speed-dreams/source-2.2.3/.gitignore
+++ b/speed-dreams/source-2.2.3/.gitignore
@@ -6,7 +6,7 @@ CMakeSettings.json
 # Build output
 out/
 build/
-cmake-build-debug/
+cmake-build-*/
 
 # Test output
 Testing/


### PR DESCRIPTION
Change the gitignore to use a wildcard for ignoring cmake build folders. This makes it so all cmake build folders following the default naming scheme will be ignored properly, instead of only the debug runs.