### PR TITLE
V22F-113 database data encryption

### DIFF
--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/SQLDatabaseStorage.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/SQLDatabaseStorage.cpp
@@ -92,6 +92,8 @@ bool SQLDatabaseStorage::OpenDatabase(
     connection_properties["port"] = p_port;
     connection_properties["OPT_RECONNECT"] = true;
     connection_properties["CLIENT_MULTI_STATEMENTS"] = false;
+    connection_properties["sslEnforce"] = true;
+    
     try { m_connection = m_driver->connect(connection_properties);}
     catch (std::exception& e) {std::cerr << "Could not open database" << std::endl; return false;}
 


### PR DESCRIPTION
Enforce data encryption when connecting to a database.

MySQL already tries to connect with encryption whenever this is possible. All this PR really does is make the system throw an error when you are connecting to a database that refuses to use encryption.