### PR TITLE
V22F-250 Remove excess UI elements

### DIFF
--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -51,7 +51,6 @@ using std::string;
 static const string rgba[4] =
     { GFSCR_ATTR_RED, GFSCR_ATTR_GREEN, GFSCR_ATTR_BLUE, GFSCR_ATTR_ALPHA };
 
-static const int NB_COUNTERS = 3;
 static const int NB_DEBUG = 4;
 
 // Boards work on a OrthoCam with fixed height of 600, width flows
@@ -98,7 +97,6 @@ void cGrBoard::loadDefaults(const tCarElt *curCar)
   snprintf(path, sizeof(path), "%s/%d", GR_SCT_DISPMODE, id);
 
   debugFlag = (int)GfParmGetNum(grHandle, path, GR_ATT_DEBUG, NULL, 1);
-  counterFlag = (int)GfParmGetNum(grHandle, path, GR_ATT_COUNTER, NULL, 1);
   boardWidth  = (int)GfParmGetNum(grHandle, path, GR_ATT_BOARDWIDTH, NULL, 100);
   speedoRise  = (int)GfParmGetNum(grHandle, path, GR_ATT_SPEEDORISE, NULL, 0);
 
@@ -107,7 +105,6 @@ void cGrBoard::loadDefaults(const tCarElt *curCar)
   if (strcmp(pszSpanSplit, GR_VAL_YES) && curCar->_driverType == RM_DRV_HUMAN) {
     snprintf(path, sizeof(path), "%s/%s", GR_SCT_DISPMODE, curCar->_name);
     debugFlag = (int)GfParmGetNum(grHandle, path, GR_ATT_DEBUG, NULL, debugFlag);
-    counterFlag   = (int)GfParmGetNum(grHandle, path, GR_ATT_COUNTER, NULL, counterFlag);
     boardWidth  = (int)GfParmGetNum(grHandle, path, GR_ATT_BOARDWIDTH, NULL, boardWidth);
     speedoRise  = (int)GfParmGetNum(grHandle, path, GR_ATT_SPEEDORISE, NULL, speedoRise);
   }
@@ -138,10 +135,6 @@ void cGrBoard::selectBoard(int val)
   snprintf(path, sizeof(path), "%s/%d", GR_SCT_DISPMODE, id);
 
   switch (val) {
-    case 1:
-      counterFlag = (counterFlag + 1) % NB_COUNTERS;
-      GfParmSetNum(grHandle, path, GR_ATT_COUNTER, (char*)NULL, (tdble)counterFlag);
-      break;
     case 3:
       debugFlag = (debugFlag + 1) % NB_DEBUG;
       GfParmSetNum(grHandle, path, GR_ATT_DEBUG, (char*)NULL, (tdble)debugFlag);
@@ -369,22 +362,6 @@ void cGrBoard::grDispCounterBoard2()
   }
 
   glTranslatef(-centerAnchor, -BOTTOM_ANCHOR, 0);
-
-  // Fuel and damage meter
-  if (counterFlag == 1) {
-    float *color;
-    if (car_->_fuel < 5.0f) {
-      color = danger_color_;    //red
-    } else {
-      color = emphasized_color_;    //yellow
-    }
-
-    grDrawGauge(centerAnchor + 140, BOTTOM_ANCHOR + 25, 100, color,
-                background_color_, car_->_fuel / car_->_tank, "F");
-    grDrawGauge(centerAnchor + 155, BOTTOM_ANCHOR + 25, 100, danger_color_, //red
-                background_color_, (tdble)(car_->_dammage) / grMaxDammage, "D");
-  }
-
   glTranslatef(0, -(speedoRise * TOP_ANCHOR / 100), 0);
 }  // grDispCounterBoard2
  
@@ -410,19 +387,17 @@ void cGrBoard::shutdown(void)
 void cGrBoard::refreshBoard(tSituation *s, const cGrFrameInfo* frameInfo,
                             const tCarElt *currCar, bool isCurrScreen)
 {
-    car_ = currCar;
-    if (isCurrScreen) {
-        grDispSplitScreenIndicator();
-    }
+    car_ = currCar;  
 
     // SIMULATED DRIVING ASSISTANCE: displays the current intervention indicators 
     DispIndicators();
- 
-    if (debugFlag)
-        grDispDebug(s, frameInfo);
 
-    if (counterFlag)
-        grDispCounterBoard2();
+    grDispCounterBoard2();
+
+    if (debugFlag) 
+        grDispDebug(s, frameInfo);
+    if (isCurrScreen) 
+        grDispSplitScreenIndicator();
 }
 
 // SIMULATED DRIVING ASSISTANCE

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.h
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.h
@@ -39,7 +39,6 @@ class cGrBoard
     const tCarElt* car_;
 
     int debugFlag;
-    int counterFlag;
     int boardWidth;
     int leftAnchor;
     int centerAnchor;

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grmain.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grmain.cpp
@@ -536,7 +536,6 @@ initView(int x, int y, int width, int height, int /* flag */, void *screen)
     GfuiAddKey(screen, GFUIK_F11,      "TV Director View",  (void*)9, grSelectCamera, NULL);
 
     GfuiAddKey(screen, '5',            "Debug Info",        (void*)3, grSelectBoard, NULL);
-    GfuiAddKey(screen, '2',            "Driver Counters",   (void*)1, grSelectBoard, NULL);
     GfuiAddKey(screen, '9',            "Mirror",            (void*)0, grSwitchMirror, NULL);
     GfuiAddKey(screen, '+', GFUIM_CTRL, "Zoom In",           (void*)GR_ZOOM_IN,	 grSetZoom, NULL);
     GfuiAddKey(screen, '=', GFUIM_CTRL, "Zoom In",           (void*)GR_ZOOM_IN,	 grSetZoom, NULL);

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -185,10 +185,11 @@ Changed:
 
                     changed cGrBoard(): removed assignments of removed members
                     changed ~cGrBoard(): removed deletes of removed members
-                    changed grInitBoardCar() 
-                    changed refreshBoard()
+                    changed grInitBoardCar(): added loading of indicator textures
+                    changed refreshBoard(): removed deleted ui elements
                     changed selectBoard(): removed cases for removed elements
                     changed loadDefaults(): removed loads of parameters for removed elements
+                    changed grDispCounterBoard2(): removed gauges
 
                     removed grDispGGraph()
                     removed grDispEngineLeds()
@@ -243,6 +244,7 @@ Changed:
                     removed leaderFlag
                     removed leaderNb
                     removed GFlag
+                    removed counterFlag
                     removed dashboardFlag
                     removed arcadeFlag
                     removed iStart


### PR DESCRIPTION
Most of them were already removed in a previous PR, but I now also removed to different counterboard options (none, only the counters, counters with fuel/damage gagues) Now only the counters remain.