### PR TITLE
V22F-537 Allow FileDataStorage to use local time

### DIFF
--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/DecisionMaker.inl
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/DecisionMaker.inl
@@ -55,13 +55,16 @@ void DecisionMaker<SocketBlackBox, SDAConfig>::Initialize(tCarElt* p_initialCar,
     BlackBox.Initialize(initialData, p_testSituations, p_testAmount);
 
     std::experimental::filesystem::path blackBoxPath = std::experimental::filesystem::path(p_blackBoxExecutablePath);
+    const std::time_t& trialStartTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    const std::time_t& blackboxFileTime = std::chrono::system_clock::to_time_t(std::experimental::filesystem::last_write_time(blackBoxPath));
+
     m_fileBufferStorage.Initialize(Config.GetDataCollectionSetting(),
                                    BUFFER_FILE_PATH,
                                    Config.GetUserId(),
-                                   std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()),
+                                   trialStartTime,
                                    blackBoxPath.filename().string(),
                                    blackBoxPath.stem().string(),
-                                   std::chrono::system_clock::to_time_t(std::experimental::filesystem::last_write_time(blackBoxPath)),
+                                   blackboxFileTime,
                                    p_track->filename,
                                    p_track->name,
                                    p_track->version,

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/FileDataStorage.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/FileDataStorage.cpp
@@ -12,12 +12,17 @@
 ///  finished by a newline.
 /// @param stream Output stream to write time to.
 /// @param date Time to format and write to the stream.
-inline void WriteTime(std::ostream& p_stream, time_t p_date)
+/// @param p_localTime boolean of whether to write the time in the timezone of the device. If false, uses GMT/UTC time.
+inline void WriteTime(std::ostream& p_stream, time_t p_date, bool p_localTime)
 {
     // "YYYY-MM-DD hh:mm:ss" is 19 characters, finishing with a nullpointer makes 20.
     // Thus allocate space for 20 characters.
     char buffer[20];
-    strftime(buffer, 20, "%F %T", gmtime(&p_date));
+
+    // Determine time based on localTime setting
+    std::tm* time = p_localTime ? localtime(&p_date) : gmtime(&p_date);
+
+    strftime(buffer, 20, "%F %T", time);
     p_stream << buffer << "\n";
 }
 
@@ -57,10 +62,10 @@ void FileDataStorage::Initialize(tDataToStore p_saveSettings,
 
     // User and trial data
     WRITE_STRING(m_outputStream, p_userId);
-    WriteTime(m_outputStream, p_trialStartTime);
+    WriteTime(m_outputStream, p_trialStartTime, m_localTime);
     // Black box data
     WRITE_STRING(m_outputStream, p_blackboxFilename);
-    WriteTime(m_outputStream, p_blackboxTime);
+    WriteTime(m_outputStream, p_blackboxTime, m_localTime);
     WRITE_STRING(m_outputStream, p_blackboxName);
     // Environment data
     WRITE_STRING(m_outputStream, p_environmentFilename);
@@ -152,4 +157,11 @@ void FileDataStorage::SaveDecisions(DecisionTuple& p_decisions)
         WRITE_VAR(m_outputStream, p_decisions.GetLights());
     }
     WRITE_STRING(m_outputStream, "NONE");
+}
+
+/// @brief Set whether to write dates and times in local time (dependent on the current timezone of the device) or in UTC/GMT time.
+/// @param p_localTime boolean of whether to write times in the timezone of the device. If false, uses GMT/UTC time.
+void FileDataStorage::SetLocalTime(bool p_localTime)
+{
+    m_localTime = p_localTime;
 }

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/FileDataStorage.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/FileDataStorage.h
@@ -36,6 +36,7 @@ public:
 
     void SaveDecisions(DecisionTuple& p_decisions);
     void SetLocalTime(bool p_localTime);
+
 private:
     bool m_localTime = false;
 };

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/FileDataStorage.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/FileDataStorage.h
@@ -33,6 +33,9 @@ public:
 
     void Save(tCarElt* p_car, tSituation* p_situation, unsigned long p_timestamp);
     void SaveDecisions(DecisionTuple& p_decisions);
+    void SetLocalTime(bool p_localTime);
+private:
+    bool m_localTime = false;
 };
 
 /// @brief Standard implementation of the file data storage


### PR DESCRIPTION
Add a boolean to FileDataStorage on whether to use local or UTC time. Defaults to false, meaning UTC time will be used as before. A function to change this boolean is available for if we decide to add this option in the future.

(very low-priority pull request)