### PR TITLE
V22F-620 Ensure proper time zone is used when inserting data

### DIFF
--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/SQLDatabaseStorage.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/SQLDatabaseStorage.cpp
@@ -153,7 +153,6 @@ bool SQLDatabaseStorage::OpenDatabase(
 
     // Create the database schema if this is a new schema. This has to be done before setting the schema on the connection.
     m_statement = m_connection->createStatement();
-
     EXECUTE("CREATE DATABASE IF NOT EXISTS " + p_schemaName)
     m_statement->close();
     delete m_statement;
@@ -164,6 +163,10 @@ bool SQLDatabaseStorage::OpenDatabase(
     // Create a (reusable) statement
     m_statement = m_connection->createStatement();
 
+    // Our system will always use UTC times. Ensure the database knows this as well.
+    EXECUTE("SET @@session.time_zone='+00:00';");
+
+    // Ensure all tables are created
     CreateTables();
 
     return true;


### PR DESCRIPTION
Set session time zone to UTC in SQLDatabaseStorage.cpp. This ensures any communication between the database and SDA is automatically interpreted as being in UTC time. 