### PR TITLE
V22F-652 Made arrow key controls unable to select labels

### DIFF
--- a/speed-dreams/source-2.2.3/src/libs/tgfclient/guiobject.cpp
+++ b/speed-dreams/source-2.2.3/src/libs/tgfclient/guiobject.cpp
@@ -436,7 +436,8 @@ gfuiSelectNext(void * /* dummy */)
 	    curObject = curObject->next;
 	    if ((curObject->focusMode != GFUI_FOCUS_NONE) &&
 		(curObject->state != GFUI_DISABLE) &&
-		(curObject->visible)) {
+		(curObject->visible) &&
+		(curObject->widget != GFUI_LABEL)) {
 		gfuiSetFocus(curObject);
 		return;
 	    }

--- a/speed-dreams/source-2.2.3/src/libs/tgfclient/guiobject.cpp
+++ b/speed-dreams/source-2.2.3/src/libs/tgfclient/guiobject.cpp
@@ -434,6 +434,7 @@ gfuiSelectNext(void * /* dummy */)
 	    
 	default:
 	    curObject = curObject->next;
+	    // SIMULATED DRIVING ASSISTANCE CHANGE: it now skips labels
 	    if ((curObject->focusMode != GFUI_FOCUS_NONE) &&
 		(curObject->state != GFUI_DISABLE) &&
 		(curObject->visible) &&
@@ -469,9 +470,11 @@ gfuiSelectPrev(void * /* dummy */)
 
 	default:
 	    curObject = curObject->prev;
+	    // SIMULATED DRIVING ASSISTANCE CHANGE: it now skips labels
 	    if ((curObject->focusMode != GFUI_FOCUS_NONE) &&
 		(curObject->state != GFUI_DISABLE) &&
-		(curObject->visible)) {
+		(curObject->visible) &&
+		(curObject->widget != GFUI_LABEL)) {
 		gfuiSetFocus(curObject);
 		return;
 	    }

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -88,6 +88,8 @@ Changed:
             guiobject.cpp
                 changed GfuiDraw()
                 changed GfuiReleaseObject()
+                changed gfuiSelectNext(): it now skips over labels
+                changed gfuiSelectPrev(): it now skips over labels
                 added   GfuiDrawString() overloaded to support different parameters.
             tgfclient.h
                 added   GFUI_RADIOBUTTON and GFUI_RADIOBUTTONLIST
@@ -96,7 +98,8 @@ Changed:
                 added   tfuiRadioButtonCallback
                 added   GfuiMenuCreateRadioButtonListControl()
 
-                added   GfuiMenuBoolToStr()
+
+
                 added   GfuiMenuControlGetBoolean()
                 
                 added   GfuiRadioButtonListCreate()

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -98,8 +98,7 @@ Changed:
                 added   tfuiRadioButtonCallback
                 added   GfuiMenuCreateRadioButtonListControl()
 
-
-
+                added   GfuiMenuBoolToStr()
                 added   GfuiMenuControlGetBoolean()
                 
                 added   GfuiRadioButtonListCreate()


### PR DESCRIPTION
It would select labels, but only if the label had a hint.